### PR TITLE
Added name exception for tests in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ You can download the finished product [here](https://github.com/NTI-Gymnasieinge
    - Classes - PascalCase
    - Variables, methods - camelCase
 - **Filename Structure:** camelCase
+    - **Exceptions**: 
+        - Tests - PascalCase
 - Comments above the code
     
 ## Definition of Done


### PR DESCRIPTION
Test filenames now use PascalCase instead of camelCase to be consistent with class names.